### PR TITLE
Remove Übertragung des Stimmrechts

### DIFF
--- a/Statuten.md
+++ b/Statuten.md
@@ -162,8 +162,7 @@ schriftlich, mittels Telefax oder per E-Mail einzureichen.
 Generalversammlung – können nur zur Tagesordnung gefasst werden.
 
 (6) Bei der Generalversammlung sind alle Mitglieder teilnahmeberechtigt. Stimmberechtigt sind nur die ordentlichen und
-die Ehrenmitglieder. Jedes Mitglied hat eine Stimme. Die Übertragung des Stimmrechts auf ein anderes Mitglied im
-Wege einer schriftlichen Bevollmächtigung ist zulässig.
+die Ehrenmitglieder. Jedes Mitglied hat eine Stimme.
 
 (7) Die Generalversammlung ist ohne Rücksicht auf die Anzahl der Erschienenen beschlussfähig.
 


### PR DESCRIPTION
Die Nachvollziehbarkeit von Abstimmungen wird dadurch schwieriger. Was mit der Übertragenen Stimme passiert ist kann schwer kontrolliert werden, die Übertragung kann nicht während der GV zurückgezogen werden.