### PR TITLE
Übertragung des Stimmrechts nicht zulässig

### DIFF
--- a/Statuten.md
+++ b/Statuten.md
@@ -163,7 +163,7 @@ Generalversammlung – können nur zur Tagesordnung gefasst werden.
 
 (6) Bei der Generalversammlung sind alle Mitglieder teilnahmeberechtigt. Stimmberechtigt sind nur die ordentlichen und
 die Ehrenmitglieder. Jedes Mitglied hat eine Stimme. Die Übertragung des Stimmrechts auf ein anderes Mitglied im
-Wege einer schriftlichen Bevollmächtigung ist zulässig.
+Wege einer schriftlichen Bevollmächtigung ist nicht zulässig.
 
 (7) Die Generalversammlung ist ohne Rücksicht auf die Anzahl der Erschienenen beschlussfähig.
 


### PR DESCRIPTION
Die Nachvollziehbarkeit von Abstimmungen wird dadurch schwieriger. Was mit der Übertragenen Stimme passiert ist kann schwer kontrolliert werden, die Übertragung kann nicht während der GV zurückgezogen werden.

Alternative zu #16